### PR TITLE
chore: minor user facing text changes to slack.py and blocks.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ venv.bak/
 .mypy_cache/
 
 .vscode
+run.py

--- a/slack_okta_bot/blocks.py
+++ b/slack_okta_bot/blocks.py
@@ -21,7 +21,7 @@ def get_reset_password_form(email) -> List[Dict]:
             },
             "accessory": {
                 "action_id": "confirm_password_reset",
-                "type": "multi_static_select",
+                "type": "static_select",
                 "placeholder": {
                     "type": "plain_text",
                     "text": "Click to select Email or Slack",

--- a/slack_okta_bot/blocks.py
+++ b/slack_okta_bot/blocks.py
@@ -9,17 +9,34 @@ def get_reset_password_form(email) -> List[Dict]:
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f":gear: *Confirm that you want to reset password for {email}. Okta will send you a password reset email.*",
+                "text": f":gear: *Confirm that you want to reset password for {email}. You can choose to recieve a password reset email or a reset link as a slack message.*",
             },
         },
         {"type": "divider"},
         {
             "type": "section",
-            "text": {"type": "mrkdwn", "text": "*Are you sure?*"},
+            "text": {
+                "type": "mrkdwn",
+                "text": ":gear: *Select reset method*",
+            },
             "accessory": {
                 "action_id": "confirm_password_reset",
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Reset My Password"},
+                "type": "multi_static_select",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Click to select Email or Slack",
+                },
+                "options": [
+                    {
+                        "text": {"type": "plain_text", "text": "Send password reset email"},
+                        "value": "send_email",
+                    },
+                    {
+                        "text": {"type": "plain_text", "text": "Send password reset link as slack message"},
+                        "value": "send_reset_link",
+                    }
+
+                ],
             },
         },
     ]

--- a/slack_okta_bot/blocks.py
+++ b/slack_okta_bot/blocks.py
@@ -9,7 +9,7 @@ def get_reset_password_form(email) -> List[Dict]:
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f":gear: *Confirm that you want to reset password for {email}. You can choose to recieve a password reset email or a reset link as a slack message.*",
+                "text": f":gear: *Confirm that you want to reset the password for the Okta account {email}. You can choose to recieve a password reset email or a reset link as a slack message.*",
             },
         },
         {"type": "divider"},
@@ -28,11 +28,11 @@ def get_reset_password_form(email) -> List[Dict]:
                 },
                 "options": [
                     {
-                        "text": {"type": "plain_text", "text": "Send password reset email"},
+                        "text": {"type": "plain_text", "text": "Send password reset email to @taxfix/personal email"},
                         "value": "send_email",
                     },
                     {
-                        "text": {"type": "plain_text", "text": "Send password reset link as slack message"},
+                        "text": {"type": "plain_text", "text": "Send password reset link as a Slack message here"},
                         "value": "send_reset_link",
                     }
 
@@ -50,14 +50,14 @@ def get_reset_mfa_form(
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f":gear: *Reset MFA Devices for {email}* :gear:",
+                "text": f":gear: *Reset MFA Devices for the Okta account {email}* :gear:",
             },
         },
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "You can select multiple devices. Resetting all MFA devices will force Okta to prompt you to re-enroll a device on next login. If you reset a single device you will be required to use an existing device for your next login and can add a device in your personal account settings.\n",
+                "text": "You can select multiple factors. Resetting all MFA factors will force Okta to prompt you to re-enroll a factor on next login. If you reset a single factor you will be required to use an existing factor for your next login and can add a factor in your personal account settings.\n",
             },
         },
         {"type": "divider"},
@@ -65,14 +65,14 @@ def get_reset_mfa_form(
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":gear: *Select MFA devices to reset*",
+                "text": ":gear: *Select MFA factors to reset*",
             },
             "accessory": {
                 "action_id": "reset_selected_mfa",
                 "type": "multi_static_select",
                 "placeholder": {
                     "type": "plain_text",
-                    "text": "Click to select MFA Devices",
+                    "text": "Click to select MFA Factors",
                 },
                 "options": [
                     {
@@ -101,7 +101,7 @@ def get_home_view() -> Dict:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\n\nTo reset MFA devices: `{RESET_MFA_COMMAND}`\nReset your password: `{RESET_PASSWORD_COMMAND}`\n\n",
+                    "text": f"\n\nTo reset MFA factors: `{RESET_MFA_COMMAND}`\nReset your password: `{RESET_PASSWORD_COMMAND}`\n\n",
                 },
             },
             {"type": "divider"},
@@ -109,7 +109,7 @@ def get_home_view() -> Dict:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\n\nWhen resetting MFA you won't be prompted on login to re-enroll if you have any other methods still enrolled. If you have at least one working MFA you can add or remove authenticators under your personal settings in Okta. Resetting all MFA devices will cause Okta to prompt you to enroll a device after a successful password login.\n\n:slack: For additional help reach out in {HELP_CHANNEL} :slack:",
+                    "text": f"\n\nWhen resetting MFA you won't be prompted on login to re-enroll if you have any other methods still enrolled. If you have at least one working MFA you can add or remove authenticators under your personal settings in Okta. Resetting all MFA factors will cause Okta to prompt you to enroll a factor after a successful password login.\n\n:ticket: For additional help submit a ticket here: {HELP_CHANNEL} :ticket:",
                 },
             },
         ],

--- a/slack_okta_bot/okta.py
+++ b/slack_okta_bot/okta.py
@@ -8,7 +8,6 @@ from requests import Session
 
 from .config import LOGGER
 
-
 # Okta auth config
 OKTA_SESSION = Session()
 try:
@@ -74,3 +73,16 @@ def send_password_email(email: str) -> int:
     res = OKTA_SESSION.post(f"{link}?sendEmail=true")
     res.raise_for_status()
     return res.status_code
+
+
+def send_reset_link(email: str) -> int:
+    # Get Okta user id from Slack email address
+    res = OKTA_SESSION.get(f"{OKTA_URL}/users/{email}")
+    res.raise_for_status()
+    link = res.json()["_links"]["resetPassword"]["href"]
+
+    # Send a password reset email
+    res = OKTA_SESSION.post(f"{link}?sendEmail=false")
+    res.raise_for_status()
+    reset_link = res.json().get("resetPasswordUrl")
+    return reset_link

--- a/slack_okta_bot/slack.py
+++ b/slack_okta_bot/slack.py
@@ -69,7 +69,7 @@ def reset_password(ack, body, respond) -> None:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": f":email: Password email has been sent to {email}. Check your email and follow the link.",
+                            "text": f":email: Password reset email has been sent to {email}. Check your email and follow the link.",
                         },
                     }
                 ]
@@ -81,7 +81,7 @@ def reset_password(ack, body, respond) -> None:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": f":exclamation: Could not reset password for {email}. Reach out in {HELP_CHANNEL} for further help.",
+                            "text": f":exclamation: Could not reset password for {email}. Submit a ticket here {HELP_CHANNEL} for further help.",
                         },
                     }
                 ]
@@ -133,7 +133,7 @@ def reset_mfa_prompt(ack, body) -> None:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"Could not find MFA devices for {email}. Reach out in {HELP_CHANNEL} for help.",
+                        "text": f"Could not find MFA devices for {email}. Submit a ticket here {HELP_CHANNEL} for further help.",
                     },
                 }
             ]
@@ -147,7 +147,7 @@ def reset_mfa_prompt(ack, body) -> None:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f":exclamation: It lools like you have no registered factors. Try logging in and if you are not prompted to configure MFA contact us at {HELP_CHANNEL}",
+                        "text": f":exclamation: It lools like you have no registered factors. Try logging in and if you are not prompted to configure MFA, submit a ticket here {HELP_CHANNEL} for further help.",
                     },
                 }
             ]

--- a/slack_okta_bot/slack.py
+++ b/slack_okta_bot/slack.py
@@ -58,7 +58,7 @@ def reset_password(ack, body, respond) -> None:
     email = (
             TEST_USER or slack_app.client.users_info(user=user)["user"]["profile"]["email"]
     )
-    selected = body["actions"][0]["selected_options"][0]["value"]
+    selected = body["actions"][0]["selected_option"]["value"]
 
     if selected == "send_email":
         try:


### PR DESCRIPTION
Text updates have been made to the blocks with clearer instructions as the user moves through the reset process. Error messaging has also been changed to allow {HELP CHANNEL} now to be called in env to use the ticketing system rather than a Slack channel.